### PR TITLE
Associate labels with inputs using for=""

### DIFF
--- a/booklet.html
+++ b/booklet.html
@@ -18,19 +18,19 @@
         <section id="addcoupon" hidden>
             <form>
                 <p class="browser-style">
-                    <label>Code</label>
+                    <label for="code">Code</label>
                     <input type="text" required id="code" placeholder="freeStuff1">
                 </p>
                 <p class="browser-style">
-                    <label>Website</label>
+                    <label for="website">Website</label>
                     <input type="url" required id="website" placeholder="https://example.com">
                 </p>
                 <p class="browser-style">
-                    <label>Valid through (optional)</label>
+                    <label for="expiryDate">Valid through (optional)</label>
                     <input type="date" id="expiryDate">
                 </p>
                 <p class="browser-style">
-                    <label>Notes (optional)</label>
+                    <label for="notes">Notes (optional)</label>
                     <textarea id="notes" placeholder="Only one item, basket value of at least 30$ etc."></textarea>
                 </p>
                 <p>


### PR DESCRIPTION
For accessibility tools to pick up that labels belong to an input one has to use `for="<id of the input>"` or the input must be a child of the label. [MDN: label](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label)
You are already a lot of semantic code and accessibility helpers like `accesskey` (which sadly can [cause some accessibility issues](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey#Accessibility_concerns)). Do you have some knowledge to share about web accessibility?